### PR TITLE
Add Instagram feed slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,19 @@
           <a href="https://wa.me/message/K5ITKCTWWUR7H1" target="_blank" rel="noopener">WhatsApp</a>
         </p>
       </div>
+      <div class="card reveal">
+        <!-- Instagram feed slider -->
+        <div class="instagram-slider">
+          <button class="prev" aria-label="Previous">&#10094;</button>
+          <div class="slides">
+            <blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="https://www.instagram.com/p/DLAlNeby99y/?utm_source=ig_embed&amp;utm_campaign=loading" data-instgrm-version="14" style="background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin:1px; max-width:540px; min-width:326px; padding:0; width:99.375%;"></blockquote>
+            <blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="https://www.instagram.com/p/DLDQ3F_y-Hf/?utm_source=ig_embed&amp;utm_campaign=loading" data-instgrm-version="14" style="background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin:1px; max-width:540px; min-width:326px; padding:0; width:99.375%;"></blockquote>
+            <blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="https://www.instagram.com/p/DNi39eBIJHB/?utm_source=ig_embed&amp;utm_campaign=loading" data-instgrm-version="14" style="background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin:1px; max-width:540px; min-width:326px; padding:0; width:99.375%;"></blockquote>
+          </div>
+          <button class="next" aria-label="Next">&#10095;</button>
+        </div>
+        <script async src="//www.instagram.com/embed.js"></script>
+      </div>
     </section>
   </main>
 

--- a/script.js
+++ b/script.js
@@ -27,4 +27,28 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.reveal').forEach((el) => {
     observer.observe(el);
   });
+
+  const slider = document.querySelector('.instagram-slider');
+  if (slider) {
+    const slides = slider.querySelectorAll('.slides blockquote');
+    let current = 0;
+
+    function showSlide(index) {
+      slides.forEach((slide, i) => {
+        slide.classList.toggle('active', i === index);
+      });
+    }
+
+    showSlide(current);
+
+    slider.querySelector('.prev').addEventListener('click', () => {
+      current = (current - 1 + slides.length) % slides.length;
+      showSlide(current);
+    });
+
+    slider.querySelector('.next').addEventListener('click', () => {
+      current = (current + 1) % slides.length;
+      showSlide(current);
+    });
+  }
 });

--- a/style.css
+++ b/style.css
@@ -83,3 +83,38 @@ footer {
 .reveal.animate {
   animation: fadeInUp 0.6s ease forwards;
 }
+
+/* Instagram slider styles */
+.instagram-slider {
+  position: relative;
+  max-width: 540px;
+  margin: 0 auto;
+}
+
+.instagram-slider .slides blockquote {
+  display: none;
+}
+
+.instagram-slider .slides blockquote.active {
+  display: block;
+}
+
+.instagram-slider button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  border-radius: 50%;
+}
+
+.instagram-slider .prev {
+  left: 10px;
+}
+
+.instagram-slider .next {
+  right: 10px;
+}


### PR DESCRIPTION
## Summary
- convert Instagram card into an Instagram slider with previous/next navigation
- style slider and add JavaScript logic to show one post at a time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d1b8c974832bad64532514222353